### PR TITLE
Makefile improvements - clean all the built files on make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ minesweeper: $(OBJS)
 	$(CC) -c $(CFLAGS) $< -o $@
 
 clean:
-	@rm -r src/**/*.o
+	@rm -r src/**/*.o bin/minesweeper

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ minesweeper: $(OBJS)
 	$(CC) -c $(CFLAGS) $< -o $@
 
 clean:
-	@rm -r src/**/*.o bin/minesweeper
+	@rm -f src/*.o src/**/*.o bin/minesweeper

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ minesweeper: $(OBJS)
 	$(CC) -c $(CFLAGS) $< -o $@
 
 clean:
-	@rm -r src/*.o
+	@rm -r src/**/*.o


### PR DESCRIPTION
**Changes to `make clean`**
1. It was not recursively deleting files under `utils/`, not sure if it works for Mac though - I'm using linux; I changed it to recursive glob and it did.
2. Make it delete the built binary too.