### PR TITLE
Create docker image for the binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM gcc:4 AS builder
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+RUN make build
+
+FROM alpine:3.6
+WORKDIR /usr/src/app
+RUN apk add --update ncurses-libs
+COPY --from=builder /usr/src/app/bin .
+
+ENV TERM=xterm-color
+ENV LANG="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8" \
+    LANGUAGE="en_US.UTF-8"
+CMD ["./minesweeper"]
+

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ CC=gcc
 SRC=src
 TEST=test
 
-LFLAGS=-lncurses
+LFLAGS=-lncurses -ltinfo
 DEBUG=-g
-CFLAGS=-Wall -std=c99 -Isrc
+CFLAGS=-static -Wall -std=c99 -Isrc
 SOURCE=$(shell find $(SRC) -type f -name '*.c')
 OBJS=$(SOURCE:.c=.o)
 TESTS=$(shell find . -type f \( -iname "*.c" ! -iname "main.c" \))
@@ -19,7 +19,7 @@ debug: CFLAGS += $(DEBUG)
 debug: clean build clean
 
 minesweeper: $(OBJS)
-	$(CC) -o bin/minesweeper $^ $(LFLAGS) $(CFLAGS)
+	$(CC) -o bin/minesweeper $^ $(CFLAGS) $(LFLAGS)
 
 minesweeper_test: $(TESTS_OBJS)
 	$(CC) -o bin/test $^ $(LFLAGS) $(CFLAGS)


### PR DESCRIPTION
- Changes to the `Makefile` to support static build that is required for lightweight docker image. Here `ncurses` was a dynamically linked library so it required to be built as static so that the binary doesn't require any run time dependencies in the image. 
- Add docker image (multi stage) for the binary.

Closes https://github.com/squgeim/minesweeper/issues/4